### PR TITLE
1.3.0

### DIFF
--- a/HierarchyControl/HierarchyControl/ControlManifest.Input.xml
+++ b/HierarchyControl/HierarchyControl/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest>
-	<control namespace="Carfup" constructor="HierarchyControl" version="1.2.0" display-name-key="Carfup.HierarchyControl" description-key="Control allowing you to visualize the hierarchy between records." control-type="virtual">
+	<control namespace="Carfup" constructor="HierarchyControl" version="1.3.0" display-name-key="Carfup.HierarchyControl" description-key="Control allowing you to visualize the hierarchy between records." control-type="virtual">
 		
 		<external-service-usage enabled="false" />
 

--- a/HierarchyControl/HierarchyControl/EntitiesDefinition.ts
+++ b/HierarchyControl/HierarchyControl/EntitiesDefinition.ts
@@ -23,6 +23,7 @@ export interface propertiesMapping {
   showZoom?: boolean;
   showSearch?: boolean;
   showRecordPicture?: boolean;
+  position?: undefined | "top" | "centered";
 }
 
 export interface fieldDefinition {

--- a/HierarchyControl/HierarchyControl/EntitiesDefinition.ts
+++ b/HierarchyControl/HierarchyControl/EntitiesDefinition.ts
@@ -7,6 +7,7 @@ export interface Mapping {
   properties?: propertiesMapping;
   isCurrentRecord?: boolean;
   recordIdValue?: string;
+  image?: string;
 }
 
 export interface attributesMapping {
@@ -21,6 +22,7 @@ export interface propertiesMapping {
   width?: number;
   showZoom?: boolean;
   showSearch?: boolean;
+  showRecordPicture?: boolean;
 }
 
 export interface fieldDefinition {

--- a/HierarchyControl/HierarchyControl/components/Main.tsx
+++ b/HierarchyControl/HierarchyControl/components/Main.tsx
@@ -175,7 +175,12 @@ const App = (props: any) => {
           type: type,
           displayName: fields.find((f: any) => f.webapiName === oldKey)
             ?.displayName,
-          statecode : obj.statecode
+          statecode : obj.statecode,
+          targetRecord : type === "lookup" ? 
+          { 
+            table : obj[`${oldKey}@Microsoft.Dynamics.CRM.lookuplogicalname`],
+            id : obj[oldKey]
+          } : null
         };
 
         if(newKey == "attribute") {

--- a/HierarchyControl/HierarchyControl/components/Main.tsx
+++ b/HierarchyControl/HierarchyControl/components/Main.tsx
@@ -50,7 +50,7 @@ const App = (props: any) => {
           ? jsonMapping.recordIdValue
           : getTopParentData.entities[0][jsonMapping.recordIdField];
 
-      const isStateCodeAware = dataEM._isStateModelAware;
+      const isStateCodeAware = dataEM.IsStateModelAware;
 ;
 
       // get all records below the top parent

--- a/HierarchyControl/HierarchyControl/components/Main.tsx
+++ b/HierarchyControl/HierarchyControl/components/Main.tsx
@@ -150,6 +150,7 @@ const App = (props: any) => {
             props.context.mode.allocatedWidth,
             height: jsonMapping.properties?.height ??
             props.context.mode.allocatedHeight}}
+          position={jsonMapping.properties?.position}
         />
       </div>
     </div>

--- a/HierarchyControl/HierarchyControl/components/Main.tsx
+++ b/HierarchyControl/HierarchyControl/components/Main.tsx
@@ -26,6 +26,15 @@ const App = (props: any) => {
   useEffect(() => {
     const getAllData = async () => {
       // Get attributes details
+
+      if(jsonMapping.properties.showRecordPicture) {
+        const hasPicture = await hasEntityPicture(jsonMapping.entityName); 
+        if (hasPicture) {
+          jsonMapping.image = `${hasPicture}_url`;
+          fields.push({  name: hasPicture });
+        }
+      }
+
       let dataEM = await props.context.utils.getEntityMetadata(
         jsonMapping.entityName,
         fields.map((u: fieldDefinition) => u.name)
@@ -51,13 +60,15 @@ const App = (props: any) => {
           : getTopParentData.entities[0][jsonMapping.recordIdField];
 
       const isStateCodeAware = dataEM.IsStateModelAware;
-;
+      
 
       // get all records below the top parent
       const concatFields = fields
         .filter((f: fieldDefinition) => f.webapiName)
         .map((f: fieldDefinition) => f.webapiName)
         .join(",");
+
+
       const getChildrenData =
         await props.context.webAPI.retrieveMultipleRecords(
           jsonMapping.entityName,
@@ -213,14 +224,16 @@ const App = (props: any) => {
   function getAttributeDetails(em: any) {
     em.Attributes.forEach((attr: any) => {
       const index = fields.findIndex((f: any) => f.name === attr.LogicalName);
+      fields[index].type = returnType(attr);
       fields[index].webapiName =
         em.PrimaryAttributeId != attr.LogicalName &&
         (attr.AttributeTypeName == "lookup" ||
           attr.AttributeTypeName == "owner" ||
           attr.AttributeTypeName == "customer")
           ? `_${attr.LogicalName}_value`
-          : attr.LogicalName;
-      fields[index].type = returnType(attr);
+          : 
+          fields[index].type === "image" ? `${attr.LogicalName}_url` : attr.LogicalName;
+      
       fields[index].displayName = attr.DisplayName;
     });
   }
@@ -232,7 +245,8 @@ const App = (props: any) => {
       propsTarget.attributes = [];
       renameKey(obj, isLookup(mapping.recordIdField), "id", propsTarget);
       renameKey(obj, isLookup(mapping.parentField), "parentId", propsTarget);
-      
+      renameKey(obj, isLookup(mapping.image!), "image", propsTarget);
+
       mapping.mapping.forEach((field: string, index : number) => {
         // First attribute is the main name of the node
         if(index == 0) {
@@ -258,14 +272,6 @@ const App = (props: any) => {
         fields.push({ name: field });
       }
     );
-
-    /*fields.push({ name: jsonMapping.mapping.name });
-    if (jsonMapping.mapping.attribute1)
-      fields.push({ name: jsonMapping.mapping.attribute1 });
-    if (jsonMapping.mapping.attribute2)
-      fields.push({ name: jsonMapping.mapping.attribute2 });
-    if (jsonMapping.mapping.attribute3)
-      fields.push({ name: jsonMapping.mapping.attribute3 });*/
 
     if (jsonMapping.lookupOtherTable) {
       fields.push({ name: jsonMapping.lookupOtherTable });
@@ -335,6 +341,15 @@ const App = (props: any) => {
     }
 
     return lookupTableDetails;
+  }
+
+  async function hasEntityPicture(entityName: string) : Promise<string> {
+    const pictureInfo = await props.context.webAPI.retrieveMultipleRecords(
+        "entityimageconfig",
+        `?$filter=parententitylogicalname eq '${entityName}'&$select=primaryimageattribute`
+      );
+
+    return pictureInfo.entities.length > 0 ? pictureInfo.entities[0].primaryimageattribute : "";
   }
 
   function jsonInputCheck(){

--- a/HierarchyControl/HierarchyControl/components/Main.tsx
+++ b/HierarchyControl/HierarchyControl/components/Main.tsx
@@ -50,6 +50,9 @@ const App = (props: any) => {
           ? jsonMapping.recordIdValue
           : getTopParentData.entities[0][jsonMapping.recordIdField];
 
+      const isStateCodeAware = dataEM._isStateModelAware;
+;
+
       // get all records below the top parent
       const concatFields = fields
         .filter((f: fieldDefinition) => f.webapiName)
@@ -58,8 +61,7 @@ const App = (props: any) => {
       const getChildrenData =
         await props.context.webAPI.retrieveMultipleRecords(
           jsonMapping.entityName,
-          `?$filter=Microsoft.Dynamics.CRM.UnderOrEqual(PropertyName='${jsonMapping.recordIdField}',PropertyValue='${getTopParentDataId}')&$select=${concatFields},statecode`
-        );
+          `?$filter=Microsoft.Dynamics.CRM.UnderOrEqual(PropertyName='${jsonMapping.recordIdField}',PropertyValue='${getTopParentDataId}')&$select=${concatFields}${isStateCodeAware ? ",statecode" : ""}`        );
 
       // format the data
       const jsonData: any = formatJson(getChildrenData.entities, jsonMapping);
@@ -175,7 +177,7 @@ const App = (props: any) => {
           type: type,
           displayName: fields.find((f: any) => f.webapiName === oldKey)
             ?.displayName,
-          statecode : obj.statecode,
+          statecode : obj.statecode !== undefined ? obj.statecode : null,
           targetRecord : type === "lookup" ? 
           { 
             table : obj[`${oldKey}@Microsoft.Dynamics.CRM.lookuplogicalname`],

--- a/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
+++ b/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
@@ -31,13 +31,17 @@ const OrgChartComponent = (props: any) => {
 
     // Loop over data and check if input value matches any name
     data.forEach((d: any) => {
-      if (
-        value != "" &&
-        d.name.value.toLowerCase().includes(value.toLowerCase())
-      ) {
+      if (value != "") {
+        // check if the name and attributes values match the search value
+        const nameMatch = d.name.value.toLowerCase().includes(value.toLowerCase());
+        const attributesMatch = d.attributes.some((attribute: any) => {
+          return attribute.value && attribute.value.toLowerCase().includes(value.toLowerCase());
+        });
         // If matches, mark node as highlighted
-        d._highlighted = true;
-        searchRecords.push({id : d.id, viewed : false});
+        if (nameMatch || attributesMatch) {
+          d._highlighted = true;
+          searchRecords.push({id : d.id, viewed : false});
+        }
       }
     });
 
@@ -98,7 +102,6 @@ const OrgChartComponent = (props: any) => {
         .container(d3Container.current)
         .data(props.data)
         .nodeWidth((_d) => 360)
-        
         .initialZoom(0.8)
         .nodeHeight((_d) =>150 ) //145
         .childrenMargin((_d) => 50)

--- a/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
+++ b/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
@@ -139,9 +139,14 @@ const OrgChartComponent = (props: any) => {
                 </div>
                 <div style="background-color:${backgroundColor};margin-top:-45px;margin-left:15px;border-radius:100px;width:50px;height:50px;"></div>
                 <div style="margin-top:-45px;">
-                  <span style="display: inline-block;background-color: ${getRandomColor()};color: #fff;border-radius: 50%;font-size: 18px;line-height: 40px;width: 40px;height: 40px;text-align: center;margin-left: 20px;font-family:'Segoe UI', sans-serif;font-weight:600;">
+                  ${d.data.image?.value ?
+                    `<span style="display: inline-block;color: #fff;border-radius: 50%;width: 40px;height: 40px;text-align: center;margin-left: 17px;">
+                    ${`<img src="https://carfupdev.crm12.dynamics.com/${d.data.image.value}" style="width: 40px;height: 40px;border-radius:50%;border:${getRandomColor()};border-style: solid;border-width: thin;"></img>`}
+                  </span>` :
+                  `<span style="display: inline-block;background-color: ${getRandomColor()};color: #fff;border-radius: 50%;font-size: 18px;line-height: 40px;width: 40px;height: 40px;text-align: center;margin-left: 20px;font-family:'Segoe UI', sans-serif;font-weight:600;">
                     ${initials}
                   </span>
+                  `}
                 </div>
                 <div style="font-size:20px;color:${textMainColor};margin-left:20px;margin-top:5px;width:320px;overflow:hidden;height:23px;">
                   ${d.data.name.value || ""}

--- a/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
+++ b/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
@@ -148,10 +148,10 @@ const OrgChartComponent = (props: any) => {
                   </span>
                   `}
                 </div>
-                <div style="font-size:20px;color:${textMainColor};margin-left:20px;margin-top:5px;width:320px;overflow:hidden;height:23px;">
+                <div style="font-size:20px;color:${textMainColor};margin-left:15px;margin-top:5px;width:340px;overflow:hidden; word-wrap: break-word;">
                   ${d.data.name.value || ""}
                 </div>
-                <div style="color:${textColor};margin-left:20px;margin-top:3px;font-size:12px;overflow:scroll;height: 82px;">
+                <div style="color:${textColor};margin-left:15px;margin-top:3px;font-size:12px;overflow:scroll;height: 82px;">
                   ${attributes}
                 </div>
               </div>

--- a/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
+++ b/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
@@ -101,10 +101,12 @@ const OrgChartComponent = (props: any) => {
         .setActiveNodeCentered(true)
         .nodeContent(function (d: any) {
           const isActiveNode = d.data.id === props.mapping.recordIdValue;
+          const statutDefinition = {
+            displayName : d.data.name.statecode !== undefined ?(d.data.name.statecode == 0 ? "Active" : "Inactive") : "",
+            color : d.data.name.statecode !== undefined ? (d.data.name.statecode == 0 ? "#58BC3A" : "#b7b7b7") : ""
+          }
           const backgroundColor = "#FFFFFF";
-          const borderColor = isActiveNode ? "#FF0000" : "#E4E2E9";
-          const statusColor = d.data.name.statecode == 0 ? "#58BC3A" : "#b7b7b7"; 
-
+          const borderColor = isActiveNode ? "#FF0000" : "#E4E2E9";          
           const textMainColor = "#08011E";
           const textColor = "#716E7B";
           const initials = (d.data.name.value || "")
@@ -127,7 +129,7 @@ const OrgChartComponent = (props: any) => {
               <div style="font-family: 'Inter', sans-serif;background-color:${backgroundColor};margin-left:-1px;width:${d.width - 2}px;height:${d.height - 27}px;border-radius:10px;border: 1px solid ${borderColor};">
                 <div style="display:flex;justify-content:flex-end;margin-top:5px;margin-right:8px;color:${textColor}">
                   <span id="navi_${d.data.id}">${getIcon("link")}</span>&nbsp;
-                              <span title="${d.data.name.statecode == 0 ? "Active" : "Inactive"}" style="height: 15px;width: 15px;background-color: ${statusColor};border-radius: 50%; display: inline-block;"></span>
+                              <span title="${statutDefinition.displayName}" style="height: 15px;width: 15px;background-color: ${statutDefinition.color};border-radius: 50%; display: inline-block;"></span>
                 </div>
                 <div style="background-color:${backgroundColor};margin-top:-45px;margin-left:15px;border-radius:100px;width:50px;height:50px;"></div>
                 <div style="margin-top:-45px;">

--- a/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
+++ b/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
@@ -166,8 +166,10 @@ const OrgChartComponent = (props: any) => {
         if(props.size.height && props.size.height != -1)
           content = content.svgHeight(props.size.height);
 
-        content = content.setCentered(props.mapping.recordIdValue)
-        .render();
+        if(props.position != undefined || props.position === "centered" ) {
+          content = content.setCentered(props.mapping.recordIdValue)
+        }
+        content.render();
 
       addListener();
     }

--- a/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
+++ b/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
@@ -166,7 +166,7 @@ const OrgChartComponent = (props: any) => {
         if(props.size.height && props.size.height != -1)
           content = content.svgHeight(props.size.height);
 
-        if(props.position != undefined || props.position === "centered" ) {
+        if(props.position == undefined || props.position === "centered" ) {
           content = content.setCentered(props.mapping.recordIdValue)
         }
         content.render();

--- a/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
+++ b/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
@@ -57,11 +57,17 @@ const OrgChartComponent = (props: any) => {
           .addEventListener("click", () => navigate(d.id));
 
            // link to the lookup attribute record
-          d.attributes.filter((record : any) => record.type === "lookup").forEach((attribute: any) => {
+          d.attributes.filter((record : any) => record.type === "lookup" || record.type === "url").forEach((attribute: any) => {
           if(attribute.type === "lookup" && attribute.value) {
               document.
               getElementById(`navi_${d.id}_${attribute.displayName}_lookuplink`)!.
               addEventListener("click", () => navigate(attribute.targetRecord.id, attribute.targetRecord.table));
+          }
+
+          if(attribute.type === "url" && attribute.value) {
+              document.
+              getElementById(`navi_${d.id}_${attribute.displayName}_lookuplink`)!.
+              addEventListener("click", () => externalUrl(attribute.value));
           }
         })
       }
@@ -185,6 +191,11 @@ const OrgChartComponent = (props: any) => {
         // Handle errors
       }
     );
+  }
+
+  function externalUrl(url : string){
+    // Open the URL in a new tab
+    window.open(url, "_blank");
   }
 
   // Get the icon based on the type

--- a/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
+++ b/HierarchyControl/HierarchyControl/components/OrgChartComponent.tsx
@@ -50,10 +50,21 @@ const OrgChartComponent = (props: any) => {
     const data: any = chartRef.current.data() as any;
 
     // attach the click listener to call the navigate function and not trigger it on load
-    data.forEach((d: any) =>
-      document
-        .getElementById(`navi_${d.id}`)!
-        .addEventListener("click", () => navigate(d.id))
+    data.forEach((d: any) => {
+        // link to the record
+        document
+          .getElementById(`navi_${d.id}`)!
+          .addEventListener("click", () => navigate(d.id));
+
+           // link to the lookup attribute record
+          d.attributes.filter((record : any) => record.type === "lookup").forEach((attribute: any) => {
+          if(attribute.type === "lookup" && attribute.value) {
+              document.
+              getElementById(`navi_${d.id}_${attribute.displayName}_lookuplink`)!.
+              addEventListener("click", () => navigate(attribute.targetRecord.id, attribute.targetRecord.table));
+          }
+        })
+      }
     );
   }
 
@@ -104,8 +115,8 @@ const OrgChartComponent = (props: any) => {
         
           const attributes = d.data.attributes.map((attribute : any) => {
               return attribute?.value
-                ? `<div style="display:flex;align-items:center" title="${attribute.displayName}">
-                     ${getIcon(attribute.type)}&nbsp;${attribute.value}
+                ? `<div style="display:flex;align-items:center" title="${attribute.displayName}" id="navi_${d.data.id}_${attribute.displayName}_lookuplink">
+                     ${getIcon(attribute.type)}&nbsp;${attribute.value} 
                    </div>`
                 : "";
             })
@@ -157,10 +168,10 @@ const OrgChartComponent = (props: any) => {
 
 
   // Standard navigate functions
-  function navigate(id: string) {
+  function navigate(id: string, entityName: string = props.mapping.entityName) {
     var pageInput = {
       pageType: "entityrecord",
-      entityName: props.mapping.entityName,
+      entityName: entityName,
       entityId: id, //replace with actual ID
     };
 

--- a/README.md
+++ b/README.md
@@ -28,14 +28,16 @@ JSON Details : (sample with the account table)
 {
 	"parentField" : "parentaccountid",  REQUIRED - Parent Record Field Link to the same Account Table (with the Hierarchy relationship enabled)
 	"recordIdField" : "accountid",      REQUIRED - Primary Field of the Account table
-	"lookupOtherTable" : "mylookupfieldid" OPTIONAL - Allow you to display the hierarchy from a lookup perspective (the base will be the lookup record)
+	"lookupOtherTable" : "mylookupfieldid" OPTIONAL - Allow you to display the hierarchy for a related table (the base will be the lookup record)
 						To properly configure it, you need to align the "parentField" and "recordIdField" with the lookup table definition
 	"mapping" : ["name","telephone1","websiteurl", "address1_line1"], REQUIRED - List of attributes to display, first one will be the node title, others will be displayed in order
 	"properties" : {
 		"height": 500,    OPTIONAL - Force the Height in px (By default use the height available)
 		"width": 1200,     OPTIONAL - Force the Width in px (By default use the full width available).
 		"showZoom": true,     OPTIONAL - Display the zoom in, zoom out, fit to screen buttons (Default value : false)
-		"showSearch": true     OPTIONAL - Display a search bar to find a node in the hierarchy (Default value : false)
+		"showSearch": true,     OPTIONAL - Display a search bar to find a node in the hierarchy (Default value : false)
+        "showRecordPicture": true,     OPTIONAL - Display the record picture instead of the initials (Default value : false)
+		"position": undefined | "top" | "centered",     OPTIONAL - Change the position of the hierarchical view : Top (center on the top parent record), centered or nothing focus on the current record
 	}
 }
 ```

--- a/Solution/Other/Solution.xml
+++ b/Solution/Other/Solution.xml
@@ -9,7 +9,7 @@
       <LocalizedName description="Carfup_PCFHierarchyControl" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0.2.0</Version>
+    <Version>1.0.3.0</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>


### PR DESCRIPTION
version 1.3.0

including : 
#34 search across name and attributes
#30 increase the size for the name while large names need to be displayed
#28 should now be fixed
#27 & #22 Capability to navigate to another record clicking on the lookup name
#25 fix for tables without statuscode
#21 capability to open the URL to a new tab
#20 new property in the JSON configuration to display or not the record image instead of the initials
#23 new property to configure the default position : centered on the current record or centered on the top parent 